### PR TITLE
fix: vanilla fuel not working

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.15.11
 
 # Mod Properties
-	mod_version = 2.3.0
+	mod_version = 2.3.1
 	maven_group = net.crioch
 	archives_base_name = fifymcc
 

--- a/src/main/java/net/crioch/fifymcc/mixin/block/entity/AbstractFurnaceBlockEntityMixin.java
+++ b/src/main/java/net/crioch/fifymcc/mixin/block/entity/AbstractFurnaceBlockEntityMixin.java
@@ -36,9 +36,7 @@ public class AbstractFurnaceBlockEntityMixin implements ComponentRecipeInputProv
 
     @Inject(method = "canUseAsFuel", at = @At("HEAD"), cancellable = true)
     private static void canUseAsFuel(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
-        ComponentMap components = stack.getComponents();
-
-        Util.LOGGER.info("Fuel Value: {}", stack.getComponents().contains(FIFYDataComponentTypes.FUEL_VALUE));
-        cir.setReturnValue(stack.getComponents().contains(FIFYDataComponentTypes.FUEL_VALUE));
+        if (stack.getComponents().contains(FIFYDataComponentTypes.FUEL_VALUE))
+            cir.setReturnValue(true);
     }
 }


### PR DESCRIPTION
Accidentally made it so vanilla fuel items wouldn't work. This patch fixes it until I can work out how to automatically apply the component to items that have a fuel value added.